### PR TITLE
uses tzinfo-data instead of system data as timezone reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "rails"
 gem "sqlite3"
 gem "pry-rails"
 gem "pry-doc"
+gem "tzinfo-data"
 
 group :development, :test do
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,8 @@ GEM
     timecop (0.8.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2016.9)
+      tzinfo (>= 1.0.0)
     yard (0.8.7.6)
 
 PLATFORMS
@@ -142,6 +144,7 @@ DEPENDENCIES
   rspec-rails
   sqlite3
   timecop
+  tzinfo-data
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,13 +13,13 @@
 
 ActiveRecord::Schema.define(version: 20141104131130) do
 
-  create_table "articles", force: true do |t|
+  create_table "articles", force: :cascade do |t|
     t.string   "title"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "users", force: true do |t|
+  create_table "users", force: :cascade do |t|
     t.string   "time_zone",  default: "UTC", null: false
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -44,21 +44,39 @@ describe Article, frozen: "2014-03-15T23:31:11+05:45" do
   end
 
   describe ActiveSupport::TimeZone do
-    describe "#parse" do
-      it "returns the time that the string represents in Kabul time" do
-        expect(Time.zone.parse("2014-03-16T23:32:11+06:00").iso8601).to eq("2014-03-16T22:02:11+04:30")
+    context "time zone is Kabul" do
+      describe "#parse" do
+        it "returns the time that the string represents in Kabul time" do
+          expect(Time.zone.parse("2014-03-16T23:32:11+06:00").iso8601).to eq("2014-03-16T22:02:11+04:30")
+        end
+      end
+
+      describe "#now" do
+        it "returns what the time is now in the configured time zone" do
+          expect(Time.zone.now.iso8601).to eq("2014-03-15T22:16:11+04:30")
+        end
+      end
+
+      describe "#today" do
+        it "returns what the date is now in the configured time zone" do
+          expect(Time.zone.today.iso8601).to eq("2014-03-15")
+        end
       end
     end
 
-    describe "#now" do
-      it "returns what the time is now in the configured time zone" do
-        expect(Time.zone.now.iso8601).to eq("2014-03-15T22:16:11+04:30")
+    context "time zone is Samoa" do
+      before do
+        Time.zone = "Pacific/Apia"
       end
-    end
 
-    describe "#today" do
-      it "returns what the date is now in the configured time zone" do
-        expect(Time.zone.today.iso8601).to eq("2014-03-15")
+      describe "data source" do
+        it "returns the correct utc_offset for Samoa" do
+          expect(Time.zone.utc_offset/3600).to eq 13
+        end
+      end
+
+      after do
+        Time.zone = "Kabul"
       end
     end
   end


### PR DESCRIPTION
With tzinfo-data excluded from the gem list in your Gemfile, the data source for timezone information is /usr/share/zoneinfo/. This is installed with the OS, and is highly likely to be out of date. For example the data in MacOS SIerra is obsolete by at least 5 years. The better source is the ruby library tzinfo-data, which is maintained and probably has the latest information. All that is necessary is to include the gem in Gemfile, and ruby's tzinfo will find it.

I ran into this problem on a project for use in Samoa, which moved to the other side of the date line in 2011, but the data in /user/share/zoneinfo does not reflect this!

If you agree, you might want to add a note in your excellent article, too.